### PR TITLE
spacy-legacy 3.0.9 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spacy-legacy" %}
 {% set modulename = "spacy_legacy" %}
-{% set version = "3.0.8" %}
+{% set version = "3.0.9" %}
 
 package:
   name: {{ name|lower }}
@@ -8,10 +8,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b4725c5c161f0685ab4fce3fc912bc68aefdb7e102ba9848e852bb5842256c2f
+  sha256: 4f7dcbc4e6c8e8cb4eadbb009f9c0a1a2a67442e0032c8d6776c9470c3759903
 
 build:
-  noarch: python
+  skip: True # [py<36]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -22,16 +22,16 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
     - {{ modulename }}
-  # requires:
-  #  - pytest
-  #  - spacy >=3.0.0,<3.1.0
-  # commands:
-  #  - python -m pytest --tb=native --pyargs {{ modulename }}
+  requires:
+    - pytest
+    - spacy >=3.1.0,<3.3.0
+  commands:
+    - python -m pytest --tb=native --pyargs {{ modulename }}
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,10 +29,10 @@ test:
     - {{ modulename }}
   requires:
     - pytest
-    - spacy >=3.1.0,<3.3.0
+    - spacy >=3.1.0,<3.3.0  # [not ((osx and arm64) or s390x)]
   commands:
     # wandb package isn't available for test_logger
-    - python -m pytest --tb=native --pyargs {{ modulename }} -k "not test_logger"
+    - python -m pytest --tb=native --pyargs {{ modulename }} -k "not test_logger"   # [not ((osx and arm64) or s390x)]
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,8 @@ test:
     - pytest
     - spacy >=3.1.0,<3.3.0
   commands:
-    - python -m pytest --tb=native --pyargs {{ modulename }}
+    # wandb package isn't available for test_logger
+    - python -m pytest --tb=native --pyargs {{ modulename }} -k "not test_logger"
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,13 @@ test:
   imports:
     - {{ modulename }}
   requires:
-    - pytest
-    - spacy >=3.1.0,<3.3.0  # [not ((osx and arm64) or s390x)]
+    - pip
+    #- pytest
+    #- spacy >=3.1.0,<3.3.
   commands:
+    - pip check
     # wandb package isn't available for test_logger
-    - python -m pytest --tb=native --pyargs {{ modulename }} -k "not test_logger"   # [not ((osx and arm64) or s390x)]
-
+    #- python -m pytest --tb=native --pyargs {{ modulename }} -k "not test_logger"
 
 about:
   home: https://github.com/explosion/spacy-legacy


### PR DESCRIPTION
License: https://github.com/explosion/spacy-legacy/blob/v3.0.9/LICENSE
Requirements:
- https://github.com/explosion/spacy-legacy/blob/v3.0.9/setup.cfg

Actions:
1. Remove noarch
2. Skip py<36
3. Add pip check